### PR TITLE
Link to Marlin instead of Marlin_LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ INCLUDE( ilcsoft_default_settings )
 
 FIND_PACKAGE( Marlin 1.0 REQUIRED ) # minimum required Marlin version
 INCLUDE_DIRECTORIES( ${Marlin_INCLUDE_DIRS} )
-LINK_LIBRARIES( ${Marlin_LIBRARIES} )
+LINK_LIBRARIES( Marlin )
 ADD_DEFINITIONS( ${Marlin_DEFINITIONS} )
 
 FIND_PACKAGE( CLHEP REQUIRED )


### PR DESCRIPTION
BEGINRELEASENOTES
- Link to `Marlin` instead of `Marlin_LIBRARIES`

ENDRELEASENOTES

Uncovered by iLCSoft/Marlin#56, only Marlin is needed by MarlinKinFit.