### PR TITLE
Remove the old cmake policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@
 # cmake file for building Marlin example Package
 # @author Jan Engels, Desy IT
 CMAKE_MINIMUM_REQUIRED(VERSION 3.23 FATAL_ERROR)
-CMAKE_POLICY(SET CMP0033 OLD)  # Allow to call export_library_dependencies
 ########################################################
 
 


### PR DESCRIPTION
No longer necessary since we no longer use the iLCSoft functionality



BEGINRELEASENOTES
- Remove a CMake policy that is no longer necessary due to the updated cmake configuration

ENDRELEASENOTES